### PR TITLE
Macro hygiene for `#![no_implicit_prelude]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,6 @@ description = "a const mem::zeroed"
 repository = "https://github.com/maxbla/const-zero"
 readme = "readme.md"
 
-[dependencies]
+[workspace]
+default-members = [".", "test-shadow-core"]
+members = [".", "test-shadow-core", "not-core"]

--- a/not-core/Cargo.toml
+++ b/not-core/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "not-core"
+version = "0.1.0"
+edition = "2018"
+license = "MIT OR Apache-2.0"
+publish = false

--- a/not-core/src/lib.rs
+++ b/not-core/src/lib.rs
@@ -1,0 +1,5 @@
+#![allow(non_camel_case_types)]
+
+pub mod primitive {
+    pub type usize = i8;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+#[doc(hidden)]
+pub use core;
+
 /// A marco that acts similarly to `std::mem::zeroed()`, only is const
 /// Example usage:
 /// ```rust
@@ -32,15 +35,15 @@
 #[macro_export]
 macro_rules! const_zero {
     ($type_:ty) => {{
-        const TYPE_SIZE: usize = core::mem::size_of::<$type_>();
+        const TYPE_SIZE: $crate::core::primitive::usize = $crate::core::mem::size_of::<$type_>();
         union TypeAsBytes {
-            bytes: [u8; TYPE_SIZE],
-            inner: core::mem::ManuallyDrop<$type_>,
+            bytes: [$crate::core::primitive::u8; TYPE_SIZE],
+            inner: $crate::core::mem::ManuallyDrop<$type_>,
         }
         const ZERO: TypeAsBytes = TypeAsBytes {
             bytes: [0; TYPE_SIZE],
         };
-        core::mem::ManuallyDrop::<$type_>::into_inner(ZERO.inner)
+        $crate::core::mem::ManuallyDrop::<$type_>::into_inner(ZERO.inner)
     }};
 }
 
@@ -134,5 +137,16 @@ mod tests {
     fn zeroed_unit() {
         const UNIT: () = unsafe { const_zero!(()) };
         assert_eq!((), UNIT);
+    }
+}
+
+#[cfg(test)]
+mod test_no_implicit_prelude {
+    #![no_implicit_prelude]
+
+    #[test]
+    fn zeroed_unit() {
+        const UNIT: () = unsafe { const_zero!(()) };
+        ::core::assert_eq!((), UNIT);
     }
 }

--- a/test-shadow-core/Cargo.toml
+++ b/test-shadow-core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-shadow-core"
+version = "0.1.0"
+edition = "2018"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+const-zero = { path = ".." }
+core = { package = "not-core", path = "../not-core" }

--- a/test-shadow-core/src/lib.rs
+++ b/test-shadow-core/src/lib.rs
@@ -1,0 +1,41 @@
+#![cfg(test)]
+
+//! In this module the name `core` / `::core` is shadowed by a non-conformant implementation.
+//!
+//! In your usual `core`, `core::primitive::usize` is an unsigned integer.
+//! In the shadowed `core`, the type is a signed integer.
+//!
+//! We want to ensure `const_core!()` works correctly in such a context, i.e.
+//!  * that the macro keeps working if e.g. `usize` / `core::primitive::usize` is another type, and
+//!  * that the user can use such a shadowed name as argument to `const_zero!()` without the
+//!    "canonical" meaning replacing the shadowed name.
+
+use const_zero::const_zero;
+use core::primitive::usize;
+
+#[test]
+fn name_in_scope() {
+    // If the macro was implemented incorrectly, this line would fail to compile, because the names
+    // `usize` / `core::primitive::usize` / `::core::primitive::usize` refer to a diffent tyep in
+    // this module than their canonical meaning.
+    const ZERO: usize = unsafe { const_zero!(usize) };
+    // This is just your baseline test if `ZERO` got initialized to `0`.
+    std::assert_eq!(ZERO, 0);
+    // If the original meaning of `usize` was leaking into the code, then this line would fail to
+    // compile, because `-1` in not a valid value for an unsigned integer.
+    std::assert_eq!(ZERO - 1, -1);
+}
+
+#[test]
+fn simple_path() {
+    const ZERO: usize = unsafe { const_zero!(core::primitive::usize) };
+    std::assert_eq!(ZERO, 0);
+    std::assert_eq!(ZERO - 1, -1);
+}
+
+#[test]
+fn qualified_path() {
+    const ZERO: usize = unsafe { const_zero!(::core::primitive::usize) };
+    std::assert_eq!(ZERO, 0);
+    std::assert_eq!(ZERO - 1, -1);
+}


### PR DESCRIPTION
This change ensures that the macro also works in a `#![no_implicit_prelude]` scope, and if `mod core` is shadowed.